### PR TITLE
Use "not" rather than == false when checking for existing dhparams file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   shell: /usr/bin/openssl dhparam -out "{{ ssl_dh_file }}" {{ ssl_dh_size }}
   args:
     chdir:
-  when: (encryption != "off") and (_dh_file_st.stat.exists == false)
+  when: (encryption != "off") and not _dh_file_st.stat.exists
 
 - include: _configure_nginx_apache_style.yml
 


### PR DESCRIPTION
See [the ansible docs on conditions](http://docs.ansible.com/ansible/playbooks_conditionals.html#the-when-statement) -- I've always hated seeing people comparing booleans in this manner...
