### PR TITLE
Add ability to use nginx ppa and add travis tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+---
+# Travis config and docker containers thanks to @geerlingguy
+sudo: false
+services: docker
+
+env:
+  - distro: debian8
+    init: /sbin/init
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distro: ubuntu1604
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distro: ubuntu1404
+    init: /sbin/init
+    run_opts: ""
+  - distro: ubuntu1204
+    init: /sbin/init
+    run_opts: ""
+
+before_install:
+  # Pull container.
+  - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
+
+script:
+  - container_id=$(mktemp)
+  # Run container in detached state.
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+
+  # Ansible syntax check.
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
+
+  # Test role.
+  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
+
+  # Test role idempotence.
+  - idempotence=$(mktemp)
+  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
+  - cat ${idempotence}
+  - >
+    tail ${idempotence}
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,6 @@ script:
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
+
+# notifications:
+#   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This Role is used to configure individual Nginx vhost-sites stored in `/etc/ngin
 | log_error_file  | no         | `/var/log/nginx/{{site_name}}_error.log` |                                  |
 | log_level       | no         | error   | `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, or `emerg` |
 | nginx_disable_default_site | no | `true`       | `true` disables the default nginx vhost                   |
-
+| nginx_use_ppa   | no       | `false`        |  **Ubuntu or Ubuntu-based systems only** If true, will use the official nginx development ppa         |
+| nginx_ppa_version | no       | `stable`        |  `stable` or `develop`                                    |
 
 ### Encryption
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Ansible Role: nginx-site
 ========================
 
+[![Build Status](https://travis-ci.org/gronke/ansible-nginx-site.svg?branch=add-travis-tests)](https://travis-ci.org/gronke/ansible-nginx-site)
+
 This Role is used to configure individual Nginx vhost-sites stored in `/etc/nginx/sites-available/`
 
 ## Configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,5 @@ log_error_file: '/var/log/nginx/{{site_name}}_error.log'
 log_level: error
 
 nginx_disable_default_site: true
+nginx_use_ppa: false
+nginx_ppa_version: stable

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,4 +4,4 @@
   service: name=nginx state=restarted
 
 - name: reload nginx
-  service: name=nginx state=restarted
+  service: name=nginx state=reloaded

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,17 @@
 ---
+- name: Add PPA for Nginx
+  apt_repository:
+    repo: 'ppa:nginx/{{ nginx_ppa_version }}'
+    state: present
+    update_cache: yes
+  register: nginx_ppa_added
+  when: (ansible_distribution == 'Ubuntu' and nginx_use_ppa)
+
+- name: Ensure nginx will reinstall if the PPA was just added.
+  apt:
+    name: nginx
+    state: absent
+  when: (ansible_distribution == 'Ubuntu' and nginx_ppa_added.changed)
 
 - name: nginx is installed
   apt:

--- a/templates/features/serve_htdocs.j2
+++ b/templates/features/serve_htdocs.j2
@@ -1,6 +1,6 @@
   root '{{feature_config.document_root}}';
   index '{{feature_config.index}}';
-  {% if php %}
+  {% if feature_config.php %}
   location ~ /$ {
     try_files $uri /index.php =404;
     fastcgi_split_path_info ^(.+\.php)(/.+)$;

--- a/templates/nginx-site.conf.j2
+++ b/templates/nginx-site.conf.j2
@@ -19,7 +19,7 @@ server {
 
 }
 {% endif %}
-{% if encryption != false %}
+{% if not encryption %}
 server {
   listen {{https_port}} ssl;
   listen [::]:{{https_port}} ssl;

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,14 @@
+---
+- hosts: all
+
+  vars:
+    encryption: "off"
+    features:
+      serve_htdocs:
+        document_root: /var/www
+        php: false
+        index: 'index.html index.html'
+
+
+  roles:
+    - role_under_test

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,6 +2,7 @@
 - hosts: all
 
   vars:
+    nginx_use_ppa: true
     encryption: "off"
     features:
       serve_htdocs:


### PR DESCRIPTION
This PR does two things (there was a dependency on #5 so I merged the two together:
- Adds the ability to use the official development PPA for nginx 
- Adds tests using docker and travis CI integration. Along the way, I fixed bugs that caused tests to fail. SSL is not tested due to...we need to figure out how to get a cert under CI....dhparams needs to be a rather small size...doesn't really matter as the containers are throwaways. 

The travis tests and the addition of the optional ability to use the PPA are in two commits.
