### PR TITLE
Debian support for `nginx_use_ppa` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ This Role is used to configure individual Nginx vhost-sites stored in `/etc/ngin
 | log_error_file  | no         | `/var/log/nginx/{{site_name}}_error.log` |                                  |
 | log_level       | no         | error   | `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, or `emerg` |
 | nginx_disable_default_site | no | `true`       | `true` disables the default nginx vhost                   |
-| nginx_use_ppa   | no       | `false`        |  **Ubuntu or Ubuntu-based systems only** If true, will use the official nginx development ppa         |
+| nginx_use_ppa   | no       | `false`        |  **Debian-based systems only** If true, the official nginx development packet sources will be used.          |
 | nginx_ppa_version | no       | `stable`        |  `stable` or `develop`                                    |
+
+#### Nginx from official development PPA
+
+When enabling the `nginx_usa_ppa` option, keep in mind this upgrades the globally installed nginx and might affect other nginx-sites. A downgrade option is not provided, but manually deleting the packet source and re-installing nginx on the specific host should rollback the changes.
 
 ### Encryption
 

--- a/tasks/_nginx_ppa.yml
+++ b/tasks/_nginx_ppa.yml
@@ -1,0 +1,61 @@
+---
+
+- name: apt-transport-https is installed
+  apt:
+    name: apt-transport-https
+    state: latest
+    cache_valid_time: 3600
+    update_cache: yes
+
+# Ubuntu
+- name: Add PPA for Nginx on Ubuntu
+  apt_repository:
+    repo: 'ppa:nginx/{{ nginx_ppa_version }}'
+    state: present
+    update_cache: yes
+  register: nginx_ppa_added_ubuntu
+  when: (ansible_distribution == 'Ubuntu' and nginx_use_ppa)
+
+# Debian
+- name: python-software-properties is installed on Debian <= 7 (Wheezy)
+  apt:
+    name: python-software-properties
+    state: latest
+  when: (ansible_distribution == "Debian") and (ansible_distribution_version.split(".")[0] < 8)
+  register: nginx_ppa_added_wheezy
+
+- name: software-properties-common is installed on Debian >= 8 (Jessie)
+  apt:
+    name: software-properties-common
+    state: latest
+  when: (ansible_distribution == "Debian") and (ansible_distribution_version.split(".")[0] >= 8)
+
+- name: nginx repository available
+  lineinfile:
+    line: 'deb https://nginx.org/packages/debian {{ansible_distribution_release}} nginx'
+    dest: /etc/apt/sources.list
+    state: present
+  register: nginx_ppa_added_debian
+
+- name: nginx repository signing keys are trusted
+  command: apt-key adv --recv-key --keyserver keys.gnupg.net 7BD9BF62
+  when: nginx_ppa_added_debian.changed
+
+- name: apt-key is updated
+  command: apt-key update
+  when: nginx_ppa_added_debian.changed
+
+# Update apt sources
+- name: Ensure nginx will reinstall if the PPA was just added.
+  apt:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - nginx
+    - nginx-common
+  when: (nginx_ppa_added_ubuntu.changed or nginx_ppa_added_debian.changed)
+
+- name: apt-packages are updated
+  apt:
+    update_cache: true
+  when: (nginx_ppa_added_ubuntu.changed or nginx_ppa_added_debian.changed)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,11 @@
 ---
-- name: Add PPA for Nginx
-  apt_repository:
-    repo: 'ppa:nginx/{{ nginx_ppa_version }}'
-    state: present
-    update_cache: yes
-  register: nginx_ppa_added
-  when: (ansible_distribution == 'Ubuntu' and nginx_use_ppa)
 
-- name: Ensure nginx will reinstall if the PPA was just added.
-  apt:
-    name: nginx
-    state: absent
-  when: (ansible_distribution == 'Ubuntu' and nginx_ppa_added.changed)
+- include: _nginx_ppa.yml
+  when: nginx_use_ppa
 
 - name: nginx is installed
   apt:
+    force: yes
     update_cache: yes
     cache_valid_time: 3600
     name: nginx
@@ -58,3 +49,12 @@
     owner: root
     group: root
   notify: reload nginx
+
+- name: nginx service is unmasked
+  command: /bin/systemctl unmask nginx
+
+- name: nginx service is enabled
+  service:
+    name: nginx
+    enabled: true
+    state: started

--- a/templates/nginx-site.conf.j2
+++ b/templates/nginx-site.conf.j2
@@ -5,7 +5,7 @@ server {
   server_name{% for alias in aliases %} {{alias}}{% endfor %};
 {% if encryption == "redirect" %}
   rewrite ^ https://{{site_name}}$request_uri? permanent;
-{% elif (encryption == false) or (encryption == "optional") %}
+{% elif (encryption == "off") or (encryption == "optional") %}
 {% for feature_name, feature_config in features.items() %}
 {% include "features/%s.j2" % feature_name %}
 
@@ -19,7 +19,7 @@ server {
 
 }
 {% endif %}
-{% if not encryption %}
+{% if encryption != "off" %}
 server {
   listen {{https_port}} ssl;
   listen [::]:{{https_port}} ssl;


### PR DESCRIPTION
Adds support for Debian Wheezy and Jessie to switch to the latest nginx version from the official packet sources.
