### PR TITLE
Bug and typo fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 # Travis config and docker containers thanks to @geerlingguy
-sudo: false
+sudo: required
+
 services: docker
 
 env:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This Role is used to configure individual Nginx vhost-sites stored in `/etc/ngin
 | log_error_file  | no         | `/var/log/nginx/{{site_name}}_error.log` |                                  |
 | log_level       | no         | error   | `debug`, `info`, `notice`, `warn`, `error`, `crit`, `alert`, or `emerg` |
 | nginx_disable_default_site | no | `true`       | `true` disables the default nginx vhost                   |
-| nginx_use_ppa   | no       | `false`        |  **Debian-based systems only** If true, the official nginx development packet sources will be used.          |
+| nginx_use_ppa   | no       | `false`        |  **Debian-based systems only** If true, the official nginx development package sources will be used.          |
 | nginx_ppa_version | no       | `stable`        |  `stable` or `develop`                                    |
 
 #### Nginx from official development PPA
@@ -87,7 +87,7 @@ Incoming requests are proxied to a different http(s) server. Very useful when th
         - '^/foo(.*)$ /bar$1'
 ```
 
-#### seafile_fasgcgi
+#### seafile_fastcgi
 
 Seafile wants a lot extra configuration. This feature is planned to be deprecated in future versions and replaced with a more generic solution for complex configurations.
 

--- a/templates/features/serve_htdocs.j2
+++ b/templates/features/serve_htdocs.j2
@@ -1,6 +1,6 @@
   root '{{feature_config.document_root}}';
   index '{{feature_config.index}}';
-  {% if feature_config.php %}
+  {% if feature_config.php is defined and features_config.php %}
   location ~ /$ {
     try_files $uri /index.php =404;
     fastcgi_split_path_info ^(.+\.php)(/.+)$;

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,9 +7,7 @@
     features:
       serve_htdocs:
         document_root: /var/www
-        php: false
-        index: 'index.html index.html'
-
+        index: 'index.html index.htm'
 
   roles:
     - role_under_test


### PR DESCRIPTION
- Typos in README 
- Allow for features.serve_htdocs.php to not exist but still function and update the test to follow what the README says.

Includes fixes from #8 and #10
